### PR TITLE
Add route with jwt-authentication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ val mockkVersion = "1.9.3"
 val orgJsonVersion = "20180813"
 val gsonVersion = "2.8.0"
 val smCommonVersion = "2019.08.08-03-52-c78281e2409af36f3ef07df4369fa29b0ea81a46"
+val nimbusdsVersion = "7.5.1"
 
 tasks.withType<Jar> {
     manifest.attributes["Main-Class"] = "no.nav.syfo.MainApplicationKt"
@@ -90,6 +91,7 @@ dependencies {
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:$spekVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
     testImplementation("io.mockk:mockk:$mockkVersion")
+    testImplementation("com.nimbusds:nimbus-jose-jwt:$nimbusdsVersion")
     testRuntimeOnly("org.spekframework.spek2:spek-runtime-jvm:$spekVersion")
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:$spekVersion")
 

--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -49,12 +49,6 @@ spec:
   env:
     - name: KTOR_ENV
       value: production
-    - name: CLIENT_ID
-      value: ""
-    - name: AADDISCOVERY_URL
-      value: ""
-    - name: JWT_ISSUER
-      value: ""
     - name: AKTORREGISTER_V1_URL
       value: "https://app-q1.adeo.no/aktoerregister/api/v1"
     - name: SECURITY_TOKEN_SERVICE_REST_URL

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -49,12 +49,6 @@ spec:
   env:
     - name: KTOR_ENV
       value: production
-    - name: CLIENT_ID
-      value: ""
-    - name: AADDISCOVERY_URL
-      value: ""
-    - name: JWT_ISSUER
-      value: ""
     - name: AKTORREGISTER_V1_URL
       value: "https://app.adeo.no/aktoerregister/api/v1"
     - name: SECURITY_TOKEN_SERVICE_REST_URL

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -17,10 +17,8 @@ fun getEnvironment(): Environment {
                 getEnvVar("APPLICATION_PORT", "8080").toInt(),
                 getEnvVar("APPLICATION_THREADS", "1").toInt(),
                 getEnvVar("APPLICATION_NAME", "syfobrukertilgang"),
-                getEnvVar("AADDISCOVERY_URL"),
-                getEnvVar("JWKKEYS_URL", "https://login.microsoftonline.com/common/discovery/keys"),
-                getEnvVar("JWT_ISSUER"),
-                getEnvVar("CLIENT_ID"),
+                getEnvVar("AAD_B2C_DISCOVERY_URL"),
+                getEnvVar("AAD_B2C_CLIENT_ID"),
                 getEnvVar("AKTORREGISTER_V1_URL"),
                 getEnvVar("SECURITY_TOKEN_SERVICE_REST_URL")
         )
@@ -33,10 +31,8 @@ data class Environment(
         val applicationPort: Int,
         val applicationThreads: Int,
         val applicationName: String,
-        val aadDiscoveryUrl: String,
-        val jwkKeysUrl: String,
-        val jwtIssuer: String,
-        val clientid: String,
+        val aadb2cDiscoveryUrl: String,
+        val aadb2cClientId: String,
         val aktoerregisterV1Url: String,
         val stsRestUrl: String
 )

--- a/src/main/kotlin/no/nav/syfo/api/OIDC.kt
+++ b/src/main/kotlin/no/nav/syfo/api/OIDC.kt
@@ -1,0 +1,41 @@
+package no.nav.syfo.api
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.apache.Apache
+import io.ktor.client.engine.apache.ApacheEngineConfig
+import io.ktor.client.features.json.JacksonSerializer
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.request.get
+import kotlinx.coroutines.runBlocking
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner
+import java.net.ProxySelector
+
+val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
+    install(JsonFeature) {
+        serializer = JacksonSerializer {
+            registerKotlinModule()
+            registerModule(JavaTimeModule())
+            configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+        }
+    }
+    engine {
+        customizeClient {
+            setRoutePlanner(SystemDefaultRoutePlanner(ProxySelector.getDefault()))
+        }
+    }
+}
+
+fun getWellKnown(wellKnownUrl: String) = runBlocking { HttpClient(Apache, proxyConfig).get<WellKnown>(wellKnownUrl) }
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class WellKnown(
+    val authorization_endpoint: String,
+    val token_endpoint: String,
+    val jwks_uri: String,
+    val issuer: String
+)

--- a/src/main/kotlin/no/nav/syfo/application/Authentication.kt
+++ b/src/main/kotlin/no/nav/syfo/application/Authentication.kt
@@ -1,0 +1,33 @@
+package no.nav.syfo.application
+
+import com.auth0.jwk.JwkProvider
+import io.ktor.application.*
+import io.ktor.auth.Authentication
+import io.ktor.auth.jwt.JWTPrincipal
+import io.ktor.auth.jwt.jwt
+import net.logstash.logback.argument.StructuredArguments
+
+fun Application.installAuthentication(
+        jwkProvider: JwkProvider,
+        issuer: String,
+        aadb2cClientId: String
+) {
+    install(Authentication) {
+        jwt(name = "jwt") {
+            verifier(jwkProvider, issuer)
+            validate { credentials ->
+                if (!credentials.payload.audience.contains(aadb2cClientId)) {
+                    log.warn(
+                            "Auth: Unexpected audience for jwt {}, {}, {}",
+                            StructuredArguments.keyValue("issuer", credentials.payload.issuer),
+                            StructuredArguments.keyValue("audience", credentials.payload.audience),
+                            StructuredArguments.keyValue("expectedAudience", aadb2cClientId)
+                    )
+                    null
+                } else {
+                    JWTPrincipal(credentials.payload)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/client/aktor/AktorregisterClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/aktor/AktorregisterClient.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.flatMap
 import com.github.kittinunf.fuel.httpGet
 import no.nav.syfo.client.sts.StsRestClient
+import no.nav.syfo.util.bearerHeader
 import org.json.JSONObject
 import org.slf4j.LoggerFactory
 
@@ -16,7 +17,7 @@ class AktorregisterClient(val baseUrl: String, val stsRestClient: StsRestClient)
 
         val (_, _, result) = "$baseUrl/identer?gjeldende=true".httpGet()
                 .header(mapOf(
-                        "Authorization" to "Bearer $bearer",
+                        "Authorization" to bearerHeader(bearer),
                         "Accept" to "application/json",
                         "Nav-Call-Id" to callId,
                         "Nav-Consumer-Id" to "syfobrukertilgang",

--- a/src/main/kotlin/no/nav/syfo/tilgang/AnsattTilgangApi.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/AnsattTilgangApi.kt
@@ -1,0 +1,40 @@
+package no.nav.syfo.tilgang
+
+import io.ktor.application.call
+import io.ktor.http.HttpStatusCode
+import io.ktor.response.respond
+import io.ktor.routing.*
+import no.nav.syfo.util.*
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+const val basePath: String = "/api/v1/tilgang/ansatt"
+
+fun Route.registerAnsattTilgangApi(
+) {
+    route(basePath) {
+        get("/{fnr}") {
+            try {
+                val fnr: String = call.parameters["fnr"]?.takeIf { validateFnr(it) }
+                        ?: throw IllegalArgumentException("Fnr mangler")
+
+                val callId = getCallId()
+
+                when (true) {
+                    true -> {
+                        call.respond(HttpStatusCode.NoContent)
+                    }
+                    else -> {
+                        log.error("Innlogget bruker har ikke tilgang til oppslått ansatt, {}", CallIdArgument(callId))
+                        call.respond(HttpStatusCode.Forbidden, "Ikke tilgang til ansatt")
+                    }
+                }
+            } catch (e: IllegalArgumentException) {
+                log.warn("Kan ikke hente tilgang til ansatt med fnr: {}, {}", e.message, CallIdArgument(getCallId()))
+                call.respond(HttpStatusCode.BadRequest, e.message ?: "Kan ikke hente tilgang til ansatt")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/util/ApiValidationUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/ApiValidationUtil.kt
@@ -1,0 +1,5 @@
+package no.nav.syfo.util
+
+fun validateFnr(fnr: String): Boolean {
+    return fnr.isNotEmpty() && fnr.matches("\\d{11}$".toRegex())
+}

--- a/src/main/resources/localEnvForTests.json
+++ b/src/main/resources/localEnvForTests.json
@@ -2,10 +2,8 @@
     "applicationPort": "8081",
     "applicationThreads": "1",
     "applicationName": "syfobrukertilgang",
-    "aadDiscoveryUrl": "https://login.microsoftonline.com/navq.onmicrosoft.com/.well-known/openid-configuration",
-    "jwkKeysUrl": "https://login.microsoftonline.com/common/discovery/keys",
-    "jwtIssuer": "https://sts.windows.net/XXXXXXXX/",
-    "clientid": "999999",
+    "aadb2cDiscoveryUrl": "https://login.microsoftonline.com/navq.onmicrosoft.com/.well-known/openid-configuration",
+    "aadb2cClientId": "999999",
     "stsRestUrl": "http://localhost:8080",
     "aktoerregisterV1Url": "http://localhost:8080"
 }

--- a/src/test/kotlin/no/nav/syfo/api/AnsattTilgangApiTestt.kt
+++ b/src/test/kotlin/no/nav/syfo/api/AnsattTilgangApiTestt.kt
@@ -1,0 +1,100 @@
+package no.nav.syfo.api
+
+import com.auth0.jwk.JwkProviderBuilder
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.ktor.application.call
+import io.ktor.application.install
+import io.ktor.auth.authenticate
+import io.ktor.features.ContentNegotiation
+import io.ktor.features.StatusPages
+import io.ktor.http.*
+import io.ktor.jackson.jackson
+import io.ktor.response.respond
+import io.ktor.routing.routing
+import io.ktor.server.testing.TestApplicationEngine
+import io.ktor.server.testing.handleRequest
+import io.ktor.util.KtorExperimentalAPI
+import no.nav.syfo.application.installAuthentication
+import no.nav.syfo.log
+import no.nav.syfo.testutil.UserConstants.ARBEIDSTAKER_FNR
+import no.nav.syfo.testutil.generateJWT
+import no.nav.syfo.tilgang.basePath
+import no.nav.syfo.tilgang.registerAnsattTilgangApi
+import no.nav.syfo.util.bearerHeader
+import org.amshove.kluent.shouldEqual
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.nio.file.Paths
+
+@KtorExperimentalAPI
+object AnsattTilgangApiTest : Spek({
+
+    val issuerUrl = "https://sts.issuer.net/myid"
+
+    val path = "src/test/resources/jwkset.json"
+    val uri = Paths.get(path).toUri().toURL()
+    val jwkProvider = JwkProviderBuilder(uri).build()
+    val consumerClientId = "1"
+    val acceptedClientId = "2"
+    val notAcceptedClientId = "4"
+
+    describe("AnsattTilgangApi") {
+        with(TestApplicationEngine()) {
+            start()
+
+            application.installAuthentication(
+                    jwkProvider,
+                    issuerUrl,
+                    acceptedClientId
+
+            )
+            application.routing {
+                authenticate("jwt") {
+                    registerAnsattTilgangApi()
+                }
+            }
+
+            application.install(ContentNegotiation) {
+                jackson {
+                    registerKotlinModule()
+                    registerModule(JavaTimeModule())
+                    configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                }
+            }
+            application.install(StatusPages) {
+                exception<Throwable> { cause ->
+                    call.respond(HttpStatusCode.InternalServerError, cause.message ?: "Unknown error")
+                    log.error("Caught exception", cause)
+                    throw cause
+                }
+            }
+
+            describe("Check access to Ansatt") {
+                it("should return 2xx-response with valid JWT and accepted audience") {
+                    with(handleRequest(HttpMethod.Get, getEndpointUrl(ARBEIDSTAKER_FNR)) {
+                        addHeader(HttpHeaders.Authorization, bearerHeader(generateJWT(consumerClientId, acceptedClientId)
+                                ?: ""))
+                    }) {
+                        response.status() shouldEqual HttpStatusCode.NoContent
+                    }
+                }
+
+                it("should return 2xx-response valid JWT and unaccepted audience") {
+                    with(handleRequest(HttpMethod.Get, getEndpointUrl(ARBEIDSTAKER_FNR)) {
+                        addHeader(HttpHeaders.Authorization, bearerHeader(generateJWT(consumerClientId, notAcceptedClientId)
+                                ?: ""))
+                    }) {
+                        response.status() shouldEqual HttpStatusCode.Unauthorized
+                        response.content shouldEqual null
+                    }
+                }
+            }
+        }
+    }
+})
+
+fun getEndpointUrl(ansattFnr: String): String {
+    return "$basePath/$ansattFnr"
+}

--- a/src/test/kotlin/no/nav/syfo/testutil/JWTUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/testutil/JWTUtils.kt
@@ -1,0 +1,58 @@
+package no.nav.syfo.testutil
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.text.ParseException
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Date
+import java.util.UUID
+
+fun generateJWT(
+    consumerClientId: String,
+    audience: String,
+    expiry: LocalDateTime? = LocalDateTime.now().plusHours(1),
+    subject: String = "subject",
+    issuer: String = "https://sts.issuer.net/myid"
+): String? {
+    val now = Date()
+    val key = getDefaultRSAKey()
+    val alg = Algorithm.RSA256(key.toRSAPublicKey(), key.toRSAPrivateKey())
+
+    return JWT.create()
+        .withKeyId(key.keyID)
+        .withSubject(subject)
+        .withIssuer(issuer)
+        .withAudience(audience)
+        .withJWTId(UUID.randomUUID().toString())
+        .withClaim("ver", "1.0")
+        .withClaim("nonce", "myNonce")
+        .withClaim("auth_time", now)
+        .withClaim("nbf", now)
+        .withClaim("azp", consumerClientId)
+        .withClaim("iat", now)
+        .withClaim("exp", Date.from(expiry?.atZone(ZoneId.systemDefault())?.toInstant()))
+        .sign(alg)
+}
+
+private fun getDefaultRSAKey(): RSAKey {
+    return getJWKSet().keys.first() as RSAKey
+}
+
+private fun getJWKSet(): JWKSet {
+    try {
+        return JWKSet.parse(getFileAsString("src/test/resources/jwkset.json"))
+    } catch (io: IOException) {
+        throw RuntimeException(io)
+    } catch (io: ParseException) {
+        throw RuntimeException(io)
+    }
+}
+
+fun getFileAsString(filePath: String) = String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8)

--- a/src/test/resources/jwkset.json
+++ b/src/test/resources/jwkset.json
@@ -1,0 +1,13 @@
+{
+    "keys": [
+    {
+        "kty": "RSA",
+        "d": "MRf73iiXUEhJFxDTtJ5rEHNQsAG8XFuXkz9vXXbMp1_OTo11bEx3SnHiwmO_mSAAeXWNJniLw07V1-nk551h5in_ueAPwXTOf8qddacvDEBZwcxeqfu_Kjh1R0ji8Xn1a037CpH2IO34Lyw2gmsGFdMZgDwa5Z0KJjPCU6W8tF6CA-2omAdNzrFaWtaPFpBC0NzYaaB111bKIXxngG97Cnu81deEEKmX-vL-O4tpvUUybuquxrlFvVlTeYlrQqv50_IKsKSYkg-iu1cbqIiWrRq9eTmA6EppmZbqHjKSM5JYFbPB_oZ9QeHKnp1_MTom-jKMEpw18qq-PzdX_skZWQ",
+        "e": "AQAB",
+        "use": "sig",
+        "kid": "localhost-signer",
+        "alg": "RS256",
+        "n": "lFTMP9TSUwLua0G8M7foqmdUS2us1-JOF8H_tClVG3IEQMRvMmHJoGSdldWDHsNwRG3Wevl_8fZoGocw9hPqj93j-vI4-ZkbxwhPyRqlS0FNIPD1Ln5R6AmHu7b-paRIz3lvqpyTRwnGBI9weE4u6WOpOQ8DjJMNPq4WcM42AgDJAvc6UuhcWW_MLIsjkKp_VYKxzthSuiRAxXi8Pz4ZhiTAEZI-UN61DYU9YEFNujg5XtIQsRwQn1Vj7BknGwkdf_iCGJgDlKUOz9hAojOMXTAwetUx6I5nngIM5vaXWJCmKn6SzcTYgHWWVrn8qaSazioaydLaYN9NuQ0MdIvsQw"
+    }
+    ]
+}


### PR DESCRIPTION
Legger til "tomt" endepunkt for sjekking av tilgang til ansatt. Bruker må være autentisert mot AzureAD b2c og whitlister clientId til loginservice.