### PR TITLE
Fix memory leak

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/OIDC.kt
+++ b/src/main/kotlin/no/nav/syfo/api/OIDC.kt
@@ -30,7 +30,7 @@ val proxyConfig: HttpClientConfig<ApacheEngineConfig>.() -> Unit = {
     }
 }
 
-fun getWellKnown(wellKnownUrl: String) = runBlocking { HttpClient(Apache, proxyConfig).get<WellKnown>(wellKnownUrl) }
+fun getWellKnown(wellKnownUrl: String) = runBlocking { HttpClient(Apache, proxyConfig).use { cli -> cli.get<WellKnown>(wellKnownUrl) } }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class WellKnown(


### PR DESCRIPTION
Wrap get-call with use in OIDC to ensure that the connection is closed