### PR TITLE
Allow workflow to generate and submit dependency graph

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -6,7 +6,7 @@ jobs:
     uses: navikt/teamesyfo-github-actions-workflows/.github/workflows/jar-app.yaml@main
     permissions:
       actions: read
-      contents: read
+      contents: write
       security-events: write
       packages: write
       id-token: write


### PR DESCRIPTION
Need to allow write permission on contents before merging navikt/teamesyfo-github-actions-workflows#11