### PR TITLE
Delete kotlinx-coroutines-core and kotlinx-coroutines-slf4j

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransf
 group = "no.nav.syfo"
 version = "1.0-SNAPSHOT"
 
-val coroutinesVersion = "1.8.1"
 val kotlinSerializationVersion = "0.20.0"
 val ktorVersion = "2.3.2"
 val logbackVersion = "1.5.12"
@@ -36,8 +35,6 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:$coroutinesVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinSerializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$kotlinSerializationVersion")
 


### PR DESCRIPTION
Dependabot upgrade of `coroutinesVersion` in [this PR](https://github.com/navikt/syfobrukertilgang/pull/140) requires upgrade of Ktor and Kotest. Next Ktor version is breaking change. 
After some testing I discovered that `coroutines` does not have to be imported as dependency at all. Build and test are green. Tested in dev: could create and access oppfolgingsplan for an employee.

