### PR TITLE
fix: oppdater Java toolchain fra 19 til 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ detekt {
 }
 
 java.toolchain {
-    languageVersion.set(JavaLanguageVersion.of(19))
+    languageVersion.set(JavaLanguageVersion.of(21))
     vendor.set(JvmVendorSpec.ADOPTIUM)
 }
 


### PR DESCRIPTION
## Hva

Oppdaterer Java toolchain i `build.gradle.kts` fra 19 til 21.

## Hvorfor

Java 19 er EOL og foojay toolchain provisioner kan ikke lenger provisjonere den. Dette fører til at **alle** Gradle-bygg feiler med:

```
Cannot find a Java installation matching: {languageVersion=19, vendor=Eclipse Temurin}
foojay: "There was an internal error and the pkg cache is currently be restored"
```

CI har vært ødelagt siden 13. april pga. dette.

## Endring

```diff
 java.toolchain {
-    languageVersion.set(JavaLanguageVersion.of(19))
+    languageVersion.set(JavaLanguageVersion.of(21))
     vendor.set(JvmVendorSpec.ADOPTIUM)
 }
```

Java 21 er LTS og allerede konfigurert i CI-workflowen (`java-version: '21'`).