### PR TITLE
docs(readme): oppdater README basert på faktisk repo-innhold

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 ## Miljøer
 
-- 🚀 [Produksjon](https://syfobrukertilgang.intern.nav.no)
-- 🛠️ [Utvikling](https://syfobrukertilgang.intern.dev.nav.no)
+🚀 [Produksjon](https://syfobrukertilgang.intern.nav.no)
+
+🛠️ [Utvikling](https://syfobrukertilgang.intern.dev.nav.no)
 
 ## Formål
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Gradle](https://img.shields.io/badge/Gradle-9.4.1-02303A?logo=gradle&logoColor=white)](https://gradle.org/)
 [![Kotest](https://img.shields.io/badge/Kotest-6.1.11-FF6B6B)](https://kotest.io/)
 
+> **Merk:** Tjenesten er kun for internt bruk av eksisterende konsumenter. Nye tjenester skal ikke integrere seg mot den.
+
 ## Formål
 
 Backend-API tjeneste som avgjør om en innlogget bruker har tilgang til en ansatt i sykefraværsoppfølgingen.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@
 [![Gradle](https://img.shields.io/badge/Gradle-9.4.1-02303A?logo=gradle&logoColor=white)](https://gradle.org/)
 [![Kotest](https://img.shields.io/badge/Kotest-6.1.11-FF6B6B)](https://kotest.io/)
 
-## Miljøer
-
-🚀 [Produksjon](https://syfobrukertilgang.intern.nav.no)
-
-🛠️ [Utvikling](https://syfobrukertilgang.intern.dev.nav.no)
-
 ## Formål
 
 Backend-API tjeneste som avgjør om en innlogget bruker har tilgang til en ansatt i sykefraværsoppfølgingen.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# syfobrukertilgang
+# API for tilgang til ansatte i sykefraværsoppfølgingen
 
 [![Build & Deploy](https://github.com/navikt/syfobrukertilgang/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/syfobrukertilgang/actions/workflows/build-and-deploy.yaml)
 
@@ -38,39 +38,6 @@ Respons:
 - `401 Unauthorized` hvis token mangler, ikke er gyldig, eller ikke inneholder `pid`
 
 Operasjonelt kan disse to `false`-utfallene skilles ved å følge Prometheus-metrikkene `syfobrukertilgang_call_narmesteleder_success_count` og `syfobrukertilgang_call_narmesteleder_fail_count` på `/prometheus`.
-
-### Drift/endepunkter
-
-- **GET** `/is_alive`
-- **GET** `/is_ready`
-- **GET** `/prometheus`
-
-## Autentisering
-
-### Inbound
-
-Den beskyttede API-ruten kjører bak `authenticate("tokenx")`.
-
-- JWT valideres mot TokenX sitt well-known/JWK-oppsett
-- tokenets audience må inneholde appens `TOKEN_X_CLIENT_ID`
-- `acr` må være `Level4` eller `idporten-loa-high`
-- `pid`-claim brukes som identen til innlogget bruker
-
-I NAIS er inbound nettverkstilgang eksplisitt åpnet for:
-
-- `syfomotebehov` (`dev-fss`, `dev-gcp`, `prod-fss`, `prod-gcp`)
-- `syfooppfolgingsplanservice` (`dev-fss`, `prod-fss`)
-- `oppfolgingsplan-backend`
-
-### Outbound
-
-Ved oppslag mot `narmesteleder` bruker appen Azure AD client credentials.
-
-- token hentes fra `AZURE_OPENID_CONFIG_TOKEN_ENDPOINT`
-- klienten autentiserer seg med `AZURE_APP_CLIENT_ID` og `AZURE_APP_CLIENT_SECRET`
-- kall går til `NARMESTELEDER_URL/leder/narmesteleder/aktive`
-- scope styres av `NARMESTELEDER_SCOPE`
-- headeren `Narmeste-Leder-Fnr` brukes for å hente aktive relasjoner for innlogget bruker
 
 ## Arkitektur
 
@@ -127,18 +94,6 @@ Applikasjonen bruker `application.conf` med `ktor.environment=dev` lokalt. Port 
 ```
 
 `./gradlew build` kjører build, tester og statisk analyse samlet.
-
-## Teknologier og observability
-
-- Kotlin
-- Ktor
-- Gradle (Kotlin DSL)
-- Jackson
-- Kotest og MockK
-- Prometheus-metrikker på `/prometheus`
-- egne tellere for vellykkede og feilede kall mot `narmesteleder`
-- NAIS-observability med logging til Elastic og Loki, samt auto-instrumentering for Java
-- alarmer for nedetid og høy andel HTTP 4xx/5xx i `nais/alerts.yaml`
 
 ## Team og kontakt
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # API for tilgang til ansatte i sykefraværsoppfølgingen
 
 [![Build & Deploy](https://github.com/navikt/syfobrukertilgang/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/syfobrukertilgang/actions/workflows/build-and-deploy.yaml)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org/)
+[![Ktor](https://img.shields.io/badge/Ktor-3.2.0-087CFA?logo=ktor&logoColor=white)](https://ktor.io/)
+[![Gradle](https://img.shields.io/badge/Gradle-9.4.1-02303A?logo=gradle&logoColor=white)](https://gradle.org/)
+[![Kotest](https://img.shields.io/badge/Kotest-6.1.11-FF6B6B)](https://kotest.io/)
 
 ## Miljøer
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,146 @@
 # syfobrukertilgang
-Access management for users(citizens and employers) of NAV Sykefraværsoppfølging.
 
-## Endpoint relative paths
-* Check logged user's access to employee: `GET /api/v2/tilgang/ansatt`
+[![Build & Deploy](https://github.com/navikt/syfobrukertilgang/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/syfobrukertilgang/actions/workflows/build-and-deploy.yaml)
 
-## Authentication
-API accepts valid tokens issued by Idporten.
+## Miljøer
 
-## Technologies used
-* Kotlin
-* Ktor
-* Gradle
-* Mockk
-* Kotest
-* AzureAD
+- 🚀 [Produksjon](https://syfobrukertilgang.intern.nav.no)
+- 🛠️ [Utvikling](https://syfobrukertilgang.intern.dev.nav.no)
 
-#### Build
-Run `./gradlew clean shadowJar`
+## Formål
 
-#### Test
-Run `./gradlew test -i`
+`syfobrukertilgang` er et backend-API som avgjør om en innlogget bruker har tilgang til en ansatt i sykefraværsoppfølgingen.
 
-#### Code analysis
-Run 
-* `./gradlew detekt` or
-* `./gradlew detekt --auto-correct`
+Tjenesten:
+
+- mottar forespørsler på vegne av en innlogget bruker
+- leser personident fra token og ansattens personident fra request-header
+- henter aktive relasjoner fra `narmesteleder`
+- svarer med `true` eller `false`
+
+## API
+
+### Beskyttet API
+
+**GET** `/api/v2/tilgang/ansatt`
+
+Header:
+
+- `Authorization: Bearer <token>`
+- `Nav-Personident: <11 siffer>`
+
+Respons:
+
+- `200 OK` med `true` eller `false`
+  - `true` betyr at tilgang ble bekreftet
+  - `false` betyr enten at brukeren ikke har en aktiv relasjon til ansatt, eller at oppslaget mot `narmesteleder` feilet
+- `400 Bad Request` hvis `Nav-Personident` mangler eller er ugyldig
+- `401 Unauthorized` hvis token mangler, ikke er gyldig, eller ikke inneholder `pid`
+
+Operasjonelt kan disse to `false`-utfallene skilles ved å følge Prometheus-metrikkene `syfobrukertilgang_call_narmesteleder_success_count` og `syfobrukertilgang_call_narmesteleder_fail_count` på `/prometheus`.
+
+### Drift/endepunkter
+
+- **GET** `/is_alive`
+- **GET** `/is_ready`
+- **GET** `/prometheus`
+
+## Autentisering
+
+### Inbound
+
+Den beskyttede API-ruten kjører bak `authenticate("tokenx")`.
+
+- JWT valideres mot TokenX sitt well-known/JWK-oppsett
+- tokenets audience må inneholde appens `TOKEN_X_CLIENT_ID`
+- `acr` må være `Level4` eller `idporten-loa-high`
+- `pid`-claim brukes som identen til innlogget bruker
+
+I NAIS er inbound nettverkstilgang eksplisitt åpnet for:
+
+- `syfomotebehov` (`dev-fss`, `dev-gcp`, `prod-fss`, `prod-gcp`)
+- `syfooppfolgingsplanservice` (`dev-fss`, `prod-fss`)
+- `oppfolgingsplan-backend`
+
+### Outbound
+
+Ved oppslag mot `narmesteleder` bruker appen Azure AD client credentials.
+
+- token hentes fra `AZURE_OPENID_CONFIG_TOKEN_ENDPOINT`
+- klienten autentiserer seg med `AZURE_APP_CLIENT_ID` og `AZURE_APP_CLIENT_SECRET`
+- kall går til `NARMESTELEDER_URL/leder/narmesteleder/aktive`
+- scope styres av `NARMESTELEDER_SCOPE`
+- headeren `Narmeste-Leder-Fnr` brukes for å hente aktive relasjoner for innlogget bruker
+
+## Arkitektur
+
+```mermaid
+graph LR
+    A[syfomotebehov / syfooppfolgingsplanservice / oppfolgingsplan-backend] -->|GET /api/v2/tilgang/ansatt<br/>TokenX + Nav-Personident| B[syfobrukertilgang]
+    B -->|Initialiserer issuer/JWK-provider ved oppstart| C[TokenX well-known / JWK]
+    B -->|Henter Azure AD-token| D[Azure AD]
+    B -->|GET /leder/narmesteleder/aktive<br/>Narmeste-Leder-Fnr| E[narmesteleder]
+    E -->|aktive relasjoner| B
+    B -->|true / false| A
+```
+
+Ved oppstart leses TokenX sitt well-known-endepunkt for å hente issuer og `jwks_uri`. Selve JWK-oppslagene håndteres deretter av JWK-provider/cache, ikke som et eksplisitt well-known-oppslag per request i applikasjonskoden.
+
+## Kom i gang
+
+### Forutsetninger
+
+- Java 21
+- tilgang til nødvendige lokale verdier for TokenX, Azure AD og `narmesteleder`
+
+### Lokal kjøring
+
+1. Opprett `src/main/resources/localEnv.json` med utgangspunkt i `src/main/resources/localEnvForTests.json`.
+2. Erstatt testverdiene med reelle verdier for:
+   - `narmestelederScope`
+   - `narmestelederUrl`
+   - `aadClientId`
+   - `aadClientSecret`
+   - `aadTokenEndpoint`
+   - `syfobrukertilgangTokenXClientId`
+   - `tokenXWellKnownUrl`
+3. Bygg kjørbar jar:
+
+   ```bash
+   ./gradlew shadowJar
+   ```
+
+4. Start appen:
+
+   ```bash
+   java -jar build/libs/syfobrukertilgang-1.0-SNAPSHOT-all.jar
+   ```
+
+Applikasjonen bruker `application.conf` med `ktor.environment=dev` lokalt. Port settes fra `localEnv.json`.
+
+### Nyttige kommandoer
+
+```bash
+./gradlew shadowJar
+./gradlew test
+./gradlew detekt
+```
+
+`./gradlew build` kjører build, tester og statisk analyse samlet.
+
+## Teknologier og observability
+
+- Kotlin
+- Ktor
+- Gradle (Kotlin DSL)
+- Jackson
+- Kotest og MockK
+- Prometheus-metrikker på `/prometheus`
+- egne tellere for vellykkede og feilede kall mot `narmesteleder`
+- NAIS-observability med logging til Elastic og Loki, samt auto-instrumentering for Java
+- alarmer for nedetid og høy andel HTTP 4xx/5xx i `nais/alerts.yaml`
+
+## Team og kontakt
+
+- Team: `team-esyfo`
+- CODEOWNERS: `@navikt/team-esyfo`

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 
 ## Formål
 
-`syfobrukertilgang` er et backend-API som avgjør om en innlogget bruker har tilgang til en ansatt i sykefraværsoppfølgingen.
-
-Tjenesten:
+Backend-API tjeneste som avgjør om en innlogget bruker har tilgang til en ansatt i sykefraværsoppfølgingen.
 
 - mottar forespørsler på vegne av en innlogget bruker
 - leser personident fra token og ansattens personident fra request-header
@@ -20,24 +18,7 @@ Tjenesten:
 
 ## API
 
-### Beskyttet API
-
 **GET** `/api/v2/tilgang/ansatt`
-
-Header:
-
-- `Authorization: Bearer <token>`
-- `Nav-Personident: <11 siffer>`
-
-Respons:
-
-- `200 OK` med `true` eller `false`
-  - `true` betyr at tilgang ble bekreftet
-  - `false` betyr enten at brukeren ikke har en aktiv relasjon til ansatt, eller at oppslaget mot `narmesteleder` feilet
-- `400 Bad Request` hvis `Nav-Personident` mangler eller er ugyldig
-- `401 Unauthorized` hvis token mangler, ikke er gyldig, eller ikke inneholder `pid`
-
-Operasjonelt kan disse to `false`-utfallene skilles ved å følge Prometheus-metrikkene `syfobrukertilgang_call_narmesteleder_success_count` og `syfobrukertilgang_call_narmesteleder_fail_count` på `/prometheus`.
 
 ## Arkitektur
 
@@ -51,9 +32,7 @@ graph LR
     B -->|true / false| A
 ```
 
-Ved oppstart leses TokenX sitt well-known-endepunkt for å hente issuer og `jwks_uri`. Selve JWK-oppslagene håndteres deretter av JWK-provider/cache, ikke som et eksplisitt well-known-oppslag per request i applikasjonskoden.
-
-## Kom i gang
+## Utvikling (kjøre lokalt)
 
 ### Forutsetninger
 
@@ -95,7 +74,6 @@ Applikasjonen bruker `application.conf` med `ktor.environment=dev` lokalt. Port 
 
 `./gradlew build` kjører build, tester og statisk analyse samlet.
 
-## Team og kontakt
+## For Nav-ansatte
 
-- Team: `team-esyfo`
-- CODEOWNERS: `@navikt/team-esyfo`
+Interne henvendelser kan sendes via Slack i kanalen [#esyfo](https://nav-it.slack.com/archives/C012X796B4L).

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+java = "21"
+
+[tasks.test]
+description = "Run tests"
+run = "./gradlew test"


### PR DESCRIPTION
## Beskrivelse

Oppdaterer README til aa reflektere faktisk applikasjonsinnhold, miljoer og lokal utvikling, og legger til en enkel `mise`-konfigurasjon for Java 21 og testing.

## Endringer

- `README.md`: erstatter generell README med repo-spesifikk dokumentasjon, badges, miljoelenker, API-beskrivelse, arkitekturdiagram og lokal kjoring
- `mise.toml`: legger til Java 21-verktøy og en `test`-oppgave for lokal utvikling

## Issue

Closes #306

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
