### PR TITLE
Upgrade netty to remove vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ val kotlinVersion = "2.3.21"
 val javaJwtVersion = "4.5.2"
 val nimbusVersion = "9.48"
 val detektVersion = "1.23.8"
+val nettyVersion = "4.1.133.Final"
 
 tasks.withType<Jar> {
     manifest.attributes["Main-Class"] = "no.nav.syfo.MainApplicationKt"
@@ -32,6 +33,8 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+extra["netty.version"] = nettyVersion
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")


### PR DESCRIPTION
## Beskrivelse

Oppdaterer runtime dependency-overrides for å lukke Google Cloud CVE-funn for Tomcat og Netty uten å hoppe til større dependency-linjer.

## Endringer

- `build.gradle.kts`: legger til `netty.version = 4.1.133.Final`

## Issue

Ingen issue. Gjelder kritiske sårbarhetsfunn fra Google Cloud scanner.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`./gradlew --no-daemon build`)
- [x] Endringene er testet med `dependencyInsight` for `netty-codec-http` og `netty-codec-dns`
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)