### PR TITLE
Upgrade netty-codec-http til 4.2.15.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ val kotlinVersion = "2.3.21"
 val javaJwtVersion = "4.5.2"
 val nimbusVersion = "9.48"
 val detektVersion = "1.23.8"
+val nettyVersion = "4.2.15.Final"
 
 tasks.withType<Jar> {
     manifest.attributes["Main-Class"] = "no.nav.syfo.MainApplicationKt"
@@ -83,7 +84,7 @@ dependencies {
     api("io.ktor:ktor-client-mock-jvm:$ktorVersion")
 
     constraints {
-        implementation("io.netty:netty-codec:4.2.14.Final")
+        implementation("io.netty:netty-codec-http:$nettyVersion")
     }
 }
 


### PR DESCRIPTION
## Beskrivelse

Oppdaterer runtime dependency-overrides for å lukke Google Cloud CVE-funn for Netty

## Endringer

- `build.gradle.kts`: oppgraderer `netty-codec-http` fra `4.2.2.Final` til  `4.2.15.Final`


## Issue

Ingen issue. Gjelder kritiske sårbarhetsfunn fra Google Cloud scanner.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`./gradlew --no-daemon build`)
- [x] Endringene er testet med `dependencyInsight` for `netty-codec-http`
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)